### PR TITLE
Fixed race condition

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,9 +3,6 @@ python = "3.13.7"
 uv = 'latest'
 node = 'latest'
 
-# NPM packages to be installed globally
-"npm:prettier" = 'latest'
-
 [env]
 PYTHONPATH = "{{config_root}}"
 _.path = ["{{config_root}}/.venv/bin"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
         "@tailwindcss/cli": "^4.1.16",
         "flowbite": "^3.1.2",
         "tailwindcss": "^4.1.16"
+      },
+      "devDependencies": {
+        "prettier": "latest"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1177,6 +1180,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "build:django": "npm run build && python manage.py collectstatic --noinput"
   },
 
+  "devDependencies": {
+    "prettier": "latest"
+  },
+
   "dependencies": {
     "@tailwindcss/cli": "^4.1.16",
     "flowbite": "^3.1.2",


### PR DESCRIPTION
Mise tried to resolve all tools in parallel, but npm:prettier requires npm. 

npm:prettier is now located in package.json as a dev dependency which runs after mise installs all tooling.